### PR TITLE
PIL-2953: Replaced println's with logger

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/Specs/GIRScenariosSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/Specs/GIRScenariosSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.api.Specs
 
 import uk.gov.hmrc.api.Specs.tags.ApiAcceptanceTests

--- a/src/test/scala/uk/gov/hmrc/api/pages/AuthPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/AuthPage.scala
@@ -56,8 +56,8 @@ object AuthPage {
 
     val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-    ApiLogger.log.info(s"Response Code: ${response.statusCode()}")
-    ApiLogger.log.info(s"Response Body: ${response.body()}")
+    ApiLogger.log.info(s"Response Code: ${response.statusCode()}\nResponse Body: ${response.body()}")
+    
     val bearerTokenHeader = response
       .headers()
       .firstValue("authorization")

--- a/src/test/scala/uk/gov/hmrc/api/pages/AuthPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/AuthPage.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.api.pages
 
 import uk.gov.hmrc.api.conf.TestEnvironment
 import uk.gov.hmrc.api.requestBody.BearerTokenGenerator._
+import uk.gov.hmrc.api.utils.ApiLogger
 
 import java.net.URI
 import java.net.http.HttpRequest.BodyPublishers
@@ -55,8 +56,8 @@ object AuthPage {
 
     val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-    println(s"Response Code: ${response.statusCode()}")
-    println(s"Response Body: ${response.body()}")
+    ApiLogger.log.info(s"Response Code: ${response.statusCode()}")
+    ApiLogger.log.info(s"Response Body: ${response.body()}")
     val bearerTokenHeader = response
       .headers()
       .firstValue("authorization")
@@ -71,7 +72,7 @@ object AuthPage {
           .getOrElse(throw new RuntimeException("BearerToken not found"))
     }
 
-    println(s"Extracted Bearer Token: $bearerToken")
+    ApiLogger.log.info(s"Extracted Bearer Token: $bearerToken")
     bearerToken
   }
 }

--- a/src/test/scala/uk/gov/hmrc/api/pages/CommonPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/CommonPage.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.api.pages
 import cats.data.Validated.{Invalid, Valid}
 import io.circe.parser
 import io.circe.schema.Schema
+import uk.gov.hmrc.api.utils.ApiLogger
 
 import java.io.File
 import scala.io.Source
@@ -31,7 +32,7 @@ object CommonPage {
       throw new RuntimeException(s"Schema file not found at: $path")
     }
 
-    println(s"Reading schema from: $path")
+    ApiLogger.log.info(s"Reading schema from: $path")
 
     val schemaContent: String = Source.fromFile(schemaFile).getLines().mkString
     val parsedSchema          = parser
@@ -48,7 +49,7 @@ object CommonPage {
     val schema = Schema.load(parsedSchema)
     schema.validate(parsedJson) match {
       case Valid(_)        =>
-        println(s"Validation successful: JSON $validationType matches schema at $path")
+        ApiLogger.log.info(s"Validation successful: JSON $validationType matches schema at $path")
       case Invalid(errors) =>
         val errorMessages = errors.toList.map(_.getMessage).mkString(", ")
         throw new AssertionError(s"JSON schema validation failed: $errorMessages")

--- a/src/test/scala/uk/gov/hmrc/api/pages/ObligationsAndSubmissionPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/ObligationsAndSubmissionPage.scala
@@ -59,8 +59,7 @@ object ObligationsAndSubmissionPage {
     state.setResponseBody(HttpResponse.body)
     val responseCode = HttpResponse.status
 
-    ApiLogger.log.info(s"Response Code: $responseCode")
-    ApiLogger.log.info(s"Response Body: ${HttpResponse.body}")
+    ApiLogger.log.info(s"Response Code: $responseCode\nResponse Body: ${HttpResponse.body}")
 
     responseCode
   }

--- a/src/test/scala/uk/gov/hmrc/api/pages/ObligationsAndSubmissionPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/ObligationsAndSubmissionPage.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.api.pages
 
 import uk.gov.hmrc.api.client.TestClient
 import uk.gov.hmrc.api.conf.TestEnvironment
+import uk.gov.hmrc.api.utils.ApiLogger
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse}
@@ -49,7 +50,7 @@ object ObligationsAndSubmissionPage {
       .withExtraHeaders("x-pillar2-id" -> pillarID)
       .copy(authorization = Some(Authorization(bearerToken)))
 
-    println(s"Sending GET request to: $requestApiUrl")
+    ApiLogger.log.info(s"Sending GET request to: $requestApiUrl")
 
     val request = httpClient.get(URI.create(requestApiUrl).toURL).withProxy
 
@@ -58,8 +59,8 @@ object ObligationsAndSubmissionPage {
     state.setResponseBody(HttpResponse.body)
     val responseCode = HttpResponse.status
 
-    println(s"Response Code: $responseCode")
-    println(s"Response Body: ${HttpResponse.body}")
+    ApiLogger.log.info(s"Response Code: $responseCode")
+    ApiLogger.log.info(s"Response Body: ${HttpResponse.body}")
 
     responseCode
   }

--- a/src/test/scala/uk/gov/hmrc/api/pages/TestOrganisationPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/TestOrganisationPage.scala
@@ -133,9 +133,7 @@ object TestOrganisationPage extends BaseSpec {
     val responseCode = response.status
     val responseBody = response.body
     state.setResponseBody(response.body)
-    ApiLogger.log.info(submissionApiUrl + endPoint)
-    ApiLogger.log.info(s" Delete Response Code: $responseCode")
-    ApiLogger.log.info(s" Delete Response Body: $responseBody")
+    ApiLogger.log.info(s"Endpoint: $submissionApiUrl + $endPoint\nDelete Response Code: $responseCode\nDelete Response Body: $responseBody")
     responseCode
   }
 

--- a/src/test/scala/uk/gov/hmrc/api/pages/TestOrganisationPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/TestOrganisationPage.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.api.Specs.BaseSpec
 import uk.gov.hmrc.api.client.TestClient
 import uk.gov.hmrc.api.conf.TestEnvironment
 import uk.gov.hmrc.api.requestBody.TestOrganisation
+import uk.gov.hmrc.api.utils.ApiLogger
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse}
@@ -49,7 +50,7 @@ object TestOrganisationPage extends BaseSpec {
 
     state.setRequestBody(Json.stringify(requestBody))
     val fullUrl = s"$submissionApiUrl$endPoint"
-    println(s"POST to: $fullUrl")
+    ApiLogger.log.info(s"POST to: $fullUrl")
 
     val response: HttpResponse = Await.result(
       httpClient
@@ -60,7 +61,7 @@ object TestOrganisationPage extends BaseSpec {
       10.seconds
     )
     state.setResponseBody(response.body)
-    println(s"Response Code: ${response.status}\nResponse Body: ${response.body}")
+    ApiLogger.log.info(s"Response Code: ${response.status}\nResponse Body: ${response.body}")
     response.status
   }
 
@@ -68,7 +69,7 @@ object TestOrganisationPage extends BaseSpec {
     val bearerToken                = state.getBearerToken
     implicit val hc: HeaderCarrier = createHeaders(bearerToken, pillarID)
     val fullUrl                    = s"$submissionApiUrl$endPoint"
-    println(s"GET from: $fullUrl")
+    ApiLogger.log.info(s"GET from: $fullUrl")
 
     val response = Await.result(
       httpClient
@@ -79,7 +80,7 @@ object TestOrganisationPage extends BaseSpec {
     )
 
     state.setResponseBody(response.body)
-    println(s"Get Response Code: ${response.status}\nGet Response Body: ${response.body}")
+    ApiLogger.log.info(s"Get Response Code: ${response.status}\nGet Response Body: ${response.body}")
     response.status
   }
 
@@ -93,7 +94,7 @@ object TestOrganisationPage extends BaseSpec {
     )
     state.setRequestBody(Json.stringify(requestBody))
     val fullUrl              = s"$submissionApiUrl$endPoint"
-    println(s"PUT to: $fullUrl")
+    ApiLogger.log.info(s"PUT to: $fullUrl")
 
     val response = Await.result(
       httpClient
@@ -105,7 +106,7 @@ object TestOrganisationPage extends BaseSpec {
     )
 
     state.setResponseBody(response.body)
-    println(s"Response Code: ${response.status}\nUpdated Response Body: ${response.body}")
+    ApiLogger.log.info(s"Response Code: ${response.status}\nUpdated Response Body: ${response.body}")
     response.status
   }
 
@@ -132,9 +133,9 @@ object TestOrganisationPage extends BaseSpec {
     val responseCode = response.status
     val responseBody = response.body
     state.setResponseBody(response.body)
-    println(submissionApiUrl + endPoint)
-    println(s" Delete Response Code: $responseCode")
-    println(s" Delete Response Body: $responseBody")
+    ApiLogger.log.info(submissionApiUrl + endPoint)
+    ApiLogger.log.info(s" Delete Response Code: $responseCode")
+    ApiLogger.log.info(s" Delete Response Body: $responseBody")
     responseCode
   }
 

--- a/src/test/scala/uk/gov/hmrc/api/pages/UKTRPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/UKTRPage.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.api.pages
 import uk.gov.hmrc.api.client.TestClient
 import uk.gov.hmrc.api.conf.TestEnvironment
 import uk.gov.hmrc.api.requestBody.{BTN, ORN, UKTR}
+import uk.gov.hmrc.api.utils.ApiLogger
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse}
@@ -50,7 +51,7 @@ object UKTRPage {
       .withProxy
 
     val response = Await.result(request.execute[HttpResponse], 5.seconds)
-    println(s"Response Code: ${response.status}")
+    ApiLogger.log.info(s"Response Code: ${response.status}")
     response.status
   }
 
@@ -122,8 +123,8 @@ object UKTRPage {
     val responseCode = response.status
     state.setResponseBody(response.body)
 
-    println(s"Response Code: $responseCode")
-    println(s"Response Body: ${state.getResponseBody}")
+    ApiLogger.log.info(s"Response Code: $responseCode")
+    ApiLogger.log.info(s"Response Body: ${state.getResponseBody}")
     responseCode
   }
 
@@ -153,8 +154,8 @@ object UKTRPage {
     val responseBody = response.json
     state.setResponseErrorCodeVal((responseBody \ "code").as[String])
     state.setResponseErrorMessage((responseBody \ "message").as[String])
-    println(s"Response Code: $responseCode")
-    println(s"Response Body: $responseBody")
+    ApiLogger.log.info(s"Response Code: $responseCode")
+    ApiLogger.log.info(s"Response Body: $responseBody")
     responseCode
   }
 }

--- a/src/test/scala/uk/gov/hmrc/api/pages/UKTRPage.scala
+++ b/src/test/scala/uk/gov/hmrc/api/pages/UKTRPage.scala
@@ -144,8 +144,7 @@ object UKTRPage {
     val responseCode = response.status
     state.setResponseBody(response.body)
 
-    ApiLogger.log.info(s"Response Code: $responseCode")
-    ApiLogger.log.info(s"Response Body: ${state.getResponseBody}")
+    ApiLogger.log.info(s"Response Code: $responseCode\nResponse Body: ${state.getResponseBody}")
     responseCode
   }
 
@@ -175,8 +174,7 @@ object UKTRPage {
     val responseBody = response.json
     state.setResponseErrorCodeVal((responseBody \ "code").as[String])
     state.setResponseErrorMessage((responseBody \ "message").as[String])
-    ApiLogger.log.info(s"Response Code: $responseCode")
-    ApiLogger.log.info(s"Response Body: $responseBody")
+    ApiLogger.log.info(s"Response Code: $responseCode\nResponse Body: $responseBody")
     responseCode
   }
 }

--- a/src/test/scala/uk/gov/hmrc/api/requestBody/GIR.scala
+++ b/src/test/scala/uk/gov/hmrc/api/requestBody/GIR.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.api.requestBody
 
 object GIR {

--- a/src/test/scala/uk/gov/hmrc/api/specdef/CommonSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specdef/CommonSteps.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.api.specdef
 
 import org.scalatest.matchers.should.Matchers
 import uk.gov.hmrc.api.pages.{CommonPage, StateStoragePage}
+import uk.gov.hmrc.api.utils.ApiLogger
 
 import java.io.File
 
@@ -53,10 +54,10 @@ object CommonSteps extends Matchers {
     val fallbackPath = s"$basePath$schemaFileName.json"
 
     val schemaPath = if (new File(primaryPath).exists()) {
-      println(s"Using schema: $primaryPath")
+      ApiLogger.log.info(s"Using schema: $primaryPath")
       primaryPath
     } else {
-      println(s"Schema not found at primary path, using fallback: $fallbackPath")
+      ApiLogger.log.info(s"Schema not found at primary path, using fallback: $fallbackPath")
       fallbackPath
     }
 

--- a/src/test/scala/uk/gov/hmrc/api/specdef/GIRSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specdef/GIRSteps.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.api.specdef
 
 import uk.gov.hmrc.api.pages.{StateStoragePage, UKTRPage}

--- a/src/test/scala/uk/gov/hmrc/api/specdef/ObligationsAndSubmissionSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specdef/ObligationsAndSubmissionSteps.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.api.specdef
 
 import uk.gov.hmrc.api.pages.{ObligationsAndSubmissionPage, StateStoragePage}
+import uk.gov.hmrc.api.utils.ApiLogger
 
 object ObligationsAndSubmissionSteps {
 
@@ -26,7 +27,7 @@ object ObligationsAndSubmissionSteps {
 
     StateStoragePage.setResponseCode(responseCode)
 
-    println(s"API call made to '$requestType' for Pillar ID '$pillarID'. Response code '$responseCode' stored.")
+    ApiLogger.log.info(s"API call made to '$requestType' for Pillar ID '$pillarID'. Response code '$responseCode' stored.")
     responseCode
   }
 }


### PR DESCRIPTION
The 3 areas that need to be moved to logger:
pillar2-api-tests (25 printlns)
pillar2-performance-tests (5 printlns)
pillar2-submission-api (1 println)